### PR TITLE
[config] 프론트엔드 포트를 3000에서 4000으로 변경

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ API_BASE_URL=http://localhost:8080
 # Frontend configuration
 NEXT_PUBLIC_API_URL=http://localhost:8080
 NEXTAUTH_SECRET=langconnect-next-server-secret
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=http://localhost:4000
 
 # MCP SSE Server configuration
 SSE_PORT=8765

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ up:
 	@echo "📌 Access points:"
 	@echo "   - API Server: http://localhost:8080"
 	@echo "   - API Docs: http://localhost:8080/docs"
-	@echo "   - Next.js UI: http://localhost:3000"
+	@echo "   - Next.js UI: http://localhost:4000"
 	@echo "   - PostgreSQL: localhost:5432"
 
 down:

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ make down
    ```
 
 2. **Access the services**
-   - 🎨 **Frontend**: http://localhost:3000
+   - 🎨 **Frontend**: http://localhost:4000
    - 📚 **API Documentation**: http://localhost:8080/docs
    - 🔍 **Health Check**: http://localhost:8080/health
 
@@ -310,7 +310,7 @@ In the Inspector:
 | `SUPABASE_URL` | Supabase project URL | Yes |
 | `SUPABASE_KEY` | Supabase anon public key | Yes |
 | `NEXTAUTH_SECRET` | NextAuth.js secret key | Yes |
-| `NEXTAUTH_URL` | NextAuth URL (default: http://localhost:3000) | Yes |
+| `NEXTAUTH_URL` | NextAuth URL (default: http://localhost:4000) | Yes |
 | `NEXT_PUBLIC_API_URL` | Public API URL for frontend | Yes |
 | `POSTGRES_HOST` | PostgreSQL host (default: postgres) | No |
 | `POSTGRES_PORT` | PostgreSQL port (default: 5432) | No |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - .env
     environment:
       API_URL: http://api:8080
-      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_URL: http://localhost:4000
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
       NEXT_PUBLIC_API_URL: http://localhost:8080
       SUPABASE_URL: ${SUPABASE_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       POSTGRES_SSLMODE: disable  # For development environment
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:${POSTGRES_PORT}/${POSTGRES_DB}
       # Allow all localhost origins
-      ALLOW_ORIGINS: '["http://localhost:3000", "http://localhost:8080", "http://localhost", "http://127.0.0.1:3000", "http://127.0.0.1:8080", "http://127.0.0.1"]'
+      ALLOW_ORIGINS: '["http://localhost:4000", "http://localhost:8080", "http://localhost", "http://127.0.0.1:4000", "http://127.0.0.1:8080", "http://127.0.0.1"]'
     volumes:
       - ./langconnect:/app/langconnect
     networks:
@@ -62,14 +62,14 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8080
-        NEXTAUTH_URL: http://localhost:3000
+        NEXTAUTH_URL: http://localhost:4000
         NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
     container_name: next-connect-ui
     restart: always
     depends_on:
       - api
     ports:
-      - "3000:3000"
+      - "4000:3000"
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## 요약
포트 충돌 해결을 위해 Next.js UI 서비스의 기본 포트를 3000번에서 4000번으로 변경했습니다.

## 변경 사항
- Docker Compose 포트 매핑 변경 (3000:3000 → 4000:3000)
- CORS 허용 출처(origin) 업데이트 (localhost:3000 → localhost:4000)
- NEXTAUTH_URL 환경변수 업데이트 (http://localhost:3000 → http://localhost:4000)
- Makefile 안내 메시지 업데이트
- README.md 및 .env.example 문서 업데이트

## 테스트 방법
- [ ] `make up` 명령으로 서비스 시작
- [ ] http://localhost:4000 에서 프론트엔드 접속 확인
- [ ] 로그인 및 인증 기능 정상 작동 확인
- [ ] CORS 에러 없이 API 통신 확인

Resolves #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 문서화
  * 기본 프론트엔드 URL과 NEXTAUTH_URL을 http://localhost:4000 기준으로 업데이트했습니다.
  * 시작 가이드, 환경 변수 표 및 관련 설명의 URL 참조를 최신화했습니다.
* 작업(Chores)
  * 개발 환경 기본 포트를 3000에서 4000으로 변경했습니다.
  * docker-compose의 Next.js 서비스 포트 매핑 및 허용 오리진을 4000 포트 기준으로 조정했습니다.
  * .env.example과 Makefile의 기본 NEXTAUTH_URL/출력 URL을 4000으로 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->